### PR TITLE
Fix bug in parallel optimizer introduced in commit 1a10b07

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ project(PIXSFM)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fPIC")  # for pybind
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fPIC -std=c++14")
 
 
 # Include helper macros and commands, and allow the included file to override
@@ -34,11 +34,6 @@ endif()
 find_package(Eigen3 3.3 REQUIRED)
 find_package(COLMAP REQUIRED)
 
-if (${CERES_VERSION} VERSION_LESS "2.0.0")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-endif()
 ################################################################################
 # Compiler specific configuration
 ################################################################################


### PR DESCRIPTION
A bug introduced while solving issue #9, which breaks reference/costmap extraction and slows down keypoint adjustment is fixed. The package now requires C++14 and GCC 4.9 or greater (similar to COLMAP).

Fixes issue #25.