### PR TITLE
Fixing missing C++14 requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(PIXSFM)
 ################################################################################
 # Include CMake dependencies
 ################################################################################
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fPIC -std=c++14")


### PR DESCRIPTION
This was missing in PR https://github.com/cvg/pixel-perfect-sfm/pull/27 and should fix https://github.com/cvg/pixel-perfect-sfm/issues/35. It was also mentioned by https://github.com/cvg/pixel-perfect-sfm/issues/9#issuecomment-1060348360.