### PR TITLE
Bugfix in pair_id_to_image_ids

### DIFF
--- a/pixsfm/util/database.py
+++ b/pixsfm/util/database.py
@@ -118,7 +118,7 @@ def image_ids_to_pair_id(image_id1, image_id2):
 
 def pair_id_to_image_ids(pair_id):
     image_id2 = pair_id % MAX_IMAGE_ID
-    image_id1 = (pair_id - image_id2) / MAX_IMAGE_ID
+    image_id1 = (pair_id - image_id2) // MAX_IMAGE_ID
     return image_id1, image_id2
 
 


### PR DESCRIPTION
In Python 3, `a / b` is a float even if `a` and `b` are both integers and `a` divisible by `b`. This bug doesn't affect our code because Python (surprisingly) autocasts to int on dict indexing.