### PR TITLE
Strict extractor config merge

### DIFF
--- a/pixsfm/features/extractor.py
+++ b/pixsfm/features/extractor.py
@@ -38,7 +38,7 @@ class FeatureExtractor:
         'max_edge': 1600,
         'model': {
             "name": "s2dnet",
-            **dynamic_load(models, "s2dnet").default_conf,
+            # model params
         },
         'patch_size': 16,
         'pyr_scales': [1.0],

--- a/pixsfm/features/models/base_model.py
+++ b/pixsfm/features/models/base_model.py
@@ -10,6 +10,7 @@ import torchvision.transforms.functional as tvf
 
 class BaseModel(nn.Module, metaclass=ABCMeta):
     default_conf = {
+        "name": "???"
     }
     output_dims = None  # num channels for each returned featuremap
     scales = None  # downscaling for each returned featuremap w.r.t input image
@@ -17,7 +18,10 @@ class BaseModel(nn.Module, metaclass=ABCMeta):
     def __init__(self, conf):
         """Perform some logic and call the _init method of the child model."""
         super().__init__()
-        self.conf = conf = OmegaConf.merge(self.default_conf, conf)
+        default_conf = OmegaConf.merge(BaseModel.default_conf,
+                                       self.default_conf)
+        OmegaConf.set_struct(default_conf, True)  # Disallow additional values
+        self.conf = conf = OmegaConf.merge(default_conf, conf)
         OmegaConf.set_readonly(conf, True)
         OmegaConf.set_struct(conf, True)
 

--- a/pixsfm/features/models/vggnet.py
+++ b/pixsfm/features/models/vggnet.py
@@ -95,5 +95,4 @@ class VGGNet(BaseModel):
             feature_maps.append(feature_map)
             start = idx + 1
 
-        feature_maps = self.adaptation_layers(feature_maps)
         return feature_maps


### PR DESCRIPTION
Throws an exception when a parameter is passed to the extractor which is not used.