### PR TITLE
:sparkles: Serialize Reference Features

### DIFF
--- a/pixsfm/features/__init__.py
+++ b/pixsfm/features/__init__.py
@@ -1,2 +1,2 @@
 from .._pixsfm._features import *  # noqa F403
-from . import models, extractor, extract_patches, store_features   # noqa F403
+from . import models, extractor, extract_patches, store_features, store_references  # noqa F403

--- a/pixsfm/features/bindings.cc
+++ b/pixsfm/features/bindings.cc
@@ -255,15 +255,17 @@ void bind_features(py::module& m) {
       .def_readwrite("is_locked", &PatchStatus::is_locked)
       .def_readwrite("reference_count", &PatchStatus::reference_count);
 
-  py::class_<Reference>(m, "Reference")
-      .def_readwrite("source", &Reference::source)
-      .def_property_readonly("descriptor", &Reference::NpArray)
-      .def_property_readonly("channels", &Reference::Channels)
-      .def_property_readonly("n_nodes", &Reference::NumNodes)
-      .def_readwrite("track", &Reference::track)
-      .def_readwrite("observations", &Reference::observations)
-      .def_readwrite("costs", &Reference::costs)
-      .def("has_observations", &Reference::HasObservations);
+  auto ref = py::class_<Reference>(m, "Reference")
+                 .def(py::init<>())
+                 .def_readwrite("source", &Reference::source)
+                 .def_property("descriptor", &Reference::NpArray, &Reference::SetNpArray)
+                 .def_property_readonly("channels", &Reference::Channels)
+                 .def_property_readonly("n_nodes", &Reference::NumNodes)
+                 .def_readwrite("track", &Reference::track)
+                 .def_readwrite("observations", &Reference::observations)
+                 .def_readwrite("costs", &Reference::costs)
+                 .def("has_observations", &Reference::HasObservations);
+  make_dataclass(ref);
 
   py::class_<DynamicPatchInterpolator>(m, "PatchInterpolator")
       .def(py::init<const InterpolationConfig&>())

--- a/pixsfm/features/src/references.cc
+++ b/pixsfm/features/src/references.cc
@@ -13,6 +13,16 @@ py::array_t<double> Reference::NpArray() const {
       dummy_data_owner);  // numpy array references this parent
 }
 
+void Reference::SetNpArray(const py::array_t<double, py::array::c_style>& desc) {
+  const py::buffer_info info = desc.request();
+  THROW_CHECK_EQ(info.ndim, 2);
+  auto *ptr = static_cast<double *>(info.ptr);
+  auto rows = static_cast<size_t>(info.shape[0]);
+  auto cols = static_cast<size_t>(info.shape[1]);
+
+  descriptor = Eigen::Map<DescriptorMatrixXd>(ptr, rows, cols); // Copy
+}
+
 const double* Reference::NodeOffsets3DData() const {
   return node_offsets3D.data();
 }

--- a/pixsfm/features/src/references.h
+++ b/pixsfm/features/src/references.h
@@ -55,6 +55,8 @@ struct Reference {
   colmap::point2D_t SourcePoint2DIdx() const;
   py::array_t<double> NpArray() const;
 
+  void SetNpArray(const py::array_t<double, py::array::c_style>& desc);
+
   int Channels() const;
   int NumNodes() const;
   bool HasObservations() const;

--- a/pixsfm/features/store_references.py
+++ b/pixsfm/features/store_references.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+from typing import Dict
+from typing import List
+from typing import Union
+
+import h5py
+from pixsfm.features import Map_IdReference
+from pixsfm.features import Reference
+from pycolmap import Track
+from pycolmap import TrackElement
+from tqdm import tqdm
+
+
+def write_references_cache(path: Path, list_map_id_refs: Union[List[Dict[int, Reference]],
+                                                               List[Map_IdReference]]):
+    """Write list of maps of feature references to cache (one per level)"""
+    with h5py.File(str(path), "w") as f:
+        f.attrs["n_levels"] = len(list_map_id_refs)
+        for lvl, map_id_refs in enumerate(list_map_id_refs):
+            lvl_grp = f.create_group(str(lvl))
+            for pt_id, reference in tqdm(map_id_refs.items(), f"Write Map_IdReference {lvl}"):
+                grp = lvl_grp.create_group(str(pt_id))
+                grp.create_dataset("descriptor", data=reference.descriptor)
+                grp.create_dataset("observations", data=reference.observations)
+                grp.create_dataset("costs", data=reference.costs)
+
+                grp.create_dataset("track_list_image_id",
+                                   data=[t.image_id for t in reference.track.elements])
+                grp.create_dataset("track_list_point2D_idx",
+                                   data=[t.point2D_idx for t in reference.track.elements])
+
+                grp.attrs["source_image_id"] = reference.source.image_id
+                grp.attrs["source_point2D_idx"] = reference.source.point2D_idx
+
+
+def load_references_from_cache(path: Path) -> List[Map_IdReference]:
+    """Load list of maps of feature references from cache (one per level)"""
+    with h5py.File(str(path), "r") as f:
+        n_levels = f.attrs["n_levels"]
+        list_map_id_refs = []
+        for lvl in range(n_levels):
+            # TODO: Bind the 'reserve' method to pre-allocate the std::unordered_map
+            map_id_refs = Map_IdReference()
+            for pt_id, grp in tqdm(f[str(lvl)].items(), f"Load Map_IdReference {lvl}"):
+                map_id_refs[int(pt_id)] = Reference(
+                    descriptor=grp["descriptor"],
+                    observations=grp["observations"],
+                    costs=grp["costs"],
+                    source=TrackElement(grp.attrs["source_image_id"],
+                                        grp.attrs["source_point2D_idx"]),
+                    track=Track([TrackElement(img_id, pt_id)
+                                 for img_id, pt_id in zip(grp["track_list_image_id"],
+                                                          grp["track_list_point2D_idx"])]))
+            list_map_id_refs.append(map_id_refs)
+        return list_map_id_refs

--- a/pixsfm/localization/main.py
+++ b/pixsfm/localization/main.py
@@ -10,7 +10,7 @@ from .. import features, bundle_adjustment as ba, logger, pyceres
 from .._pixsfm import _localization as loc
 from ..base import interpolation_default_conf, solver_default_conf
 from ..features.extractor import FeatureExtractor
-from ..features import Reference, FeatureManager
+from ..features import FeatureManager, Map_IdReference
 from ..extract import features_from_reconstruction, load_features_from_cache
 from ..configs import parse_config_path
 from ..util.misc import resolve_level_indices, to_ctr, to_optim_ctr
@@ -47,7 +47,7 @@ def find_unique_inliers(idxs, pre_inliers=None):
 
 
 def find_unique_min_by_group(errors, idxs, pre_inliers=None):
-    assert(len(idxs) == len(errors))
+    assert (len(idxs) == len(errors))
     if pre_inliers is None:
         pre_inliers = [True] * len(idxs)
     errs_by_group = defaultdict(list)
@@ -249,7 +249,7 @@ class QueryBundleAdjuster:
             references: List[List[Union[np.ndarray, features.Reference]]],
             inliers: Optional[List[bool]] = None,
             point2D_idxs:  Optional[List[int]] = None):
-        assert(len(fmaps) == len(references))
+        assert (len(fmaps) == len(references))
         levels = resolve_level_indices(self.conf.level_indices, len(fmaps))
         for level in levels:
             self.refine(qvec, tvec, camera, points3D, fmaps[level],
@@ -300,7 +300,7 @@ class QueryLocalizer:
             conf: Optional[Union[str, dict, DictConfig]] = None,
             dense_features: Optional[Union[Path, FeatureManager]] = None,
             image_dir: Optional[Path] = None,
-            references: Optional[Dict[int, Reference]] = None,
+            references: Optional[List[Map_IdReference]] = None,
             extractor: Optional[FeatureExtractor] = None):
         """Query localizer.
         Holds reconstruction, extractor and references for each 3D point
@@ -380,11 +380,12 @@ class QueryLocalizer:
             self.target_reference_funcs[self.conf.target_reference]
 
         self.references = references
+        # Assure that extractor is valid
+        if self.extractor is None:
+            self.extractor = FeatureExtractor(self.conf.dense_features)
+
         if (self.references is None and
                 (self.conf.QKA.apply or self.conf.QBA.apply)):
-            # Assure that extractor is valid
-            if self.extractor is None:
-                self.extractor = FeatureExtractor(self.conf.dense_features)
             # if dense_features are a path instance, we load the
             # features from cache
             if isinstance(dense_features, Path):
@@ -393,7 +394,7 @@ class QueryLocalizer:
                 else:
                     dense_features = None
             if dense_features is None:
-                assert(image_dir is not None)
+                assert (image_dir is not None)
                 dense_features = features_from_reconstruction(
                     self.extractor, reconstruction, image_dir,
                     cache_path=dense_features)
@@ -417,8 +418,8 @@ class QueryLocalizer:
             query_camera: pycolmap.Camera,
             image_path: Path = None,
             query_fmaps: Optional[List[features.FeatureMap]] = None):
-        assert(len(pnp_point2D_idxs) == len(pnp_points3D_id))
-        assert(image_path is not None or query_fmaps is not None)
+        assert (len(pnp_point2D_idxs) == len(pnp_points3D_id))
+        assert (image_path is not None or query_fmaps is not None)
         if len(pnp_point2D_idxs) == 0:
             return {"success": False}
         pnp_points3D = [self.reconstruction.points3D[p3D_id].xyz
@@ -441,7 +442,7 @@ class QueryLocalizer:
         if require_feats:
             query_references = self.get_query_references(
                 pnp_points3D_id, query_fmaps, pnp_points2D, pnp_point2D_idxs)
-            assert(len(query_fmaps) == len(query_references))
+            assert (len(query_fmaps) == len(query_references))
 
         # Run QKA
         if self.conf.QKA.apply:


### PR DESCRIPTION
- Make "Reference" a dataclass
- Add descriptor setter from numpy for the "Reference" class
- Add I/O utils

N.B. It could be useful to have pycolmap::Track and pycolmap::TrackElement behave like dataclasses (constructor with kwargs)