### PR TITLE
Add AVX2 check and fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,17 +49,24 @@ set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 ################################################################################
 
 if (AVX2_ENABLED)
-  add_definitions("-DAVX2_ENABLED")
-  message("Compiling with AVX2 support.")
-  # @TODO investigate linking with non-avx code, it works on some machines without
-  # -DEIGEN_DONT_VECTORIZE
-  # We assume here colmap was compiled with default flags, thus we need to set
-  # -DEIGEN_MAX_ALIGN_BYTES=16 to avoid segfaults (otherwise eigen aligns
-  # on 32 bytes if avx2 enabled)
-  set(EIGEN_DISABLE_ALIGN_FLAGS
-    "-DEIGEN_MAX_ALIGN_BYTES=16 -DEIGEN_MAX_STATIC_ALIGN_BYTES=16 -DEIGEN_DONT_VECTORIZE")
-  set (AVX2_CXX_FLAGS "-mavx2 -mf16c -mfma")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${AVX2_CXX_FLAGS} ${EIGEN_DISABLE_ALIGN_FLAGS}")
+  include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindAVX2.cmake")
+  CHECK_FOR_AVX2()
+  if(HAVE_AVX2)
+    add_definitions("-DAVX2_ENABLED")
+    message("Compiling with AVX2 support.")
+    # @TODO investigate linking with non-avx code, it works on some machines without
+    # -DEIGEN_DONT_VECTORIZE
+    # We assume here colmap was compiled with default flags, thus we need to set
+    # -DEIGEN_MAX_ALIGN_BYTES=16 to avoid segfaults (otherwise eigen aligns
+    # on 32 bytes if avx2 enabled)
+    set(EIGEN_DISABLE_ALIGN_FLAGS
+      "-DEIGEN_MAX_ALIGN_BYTES=16 -DEIGEN_MAX_STATIC_ALIGN_BYTES=16 -DEIGEN_DONT_VECTORIZE")
+    set (AVX2_CXX_FLAGS "-mavx2 -mf16c -mfma")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${AVX2_CXX_FLAGS} ${EIGEN_DISABLE_ALIGN_FLAGS}")
+  else()
+    message("Compiling without AVX2 support.")
+    set(AVX2_ENABLED OFF)
+  endif()
 endif()
 
 if (NOT EXISTS ${CMAKE_BINARY_DIR}/CMakeCache.txt)

--- a/cmake/FindAVX2.cmake
+++ b/cmake/FindAVX2.cmake
@@ -1,0 +1,45 @@
+#source: https://github.com/PointCloudLibrary/pcl/blob/5f2125ff205d2db5167ad83b276a3d39252e2f3b/cmake/pcl_find_avx.cmake#L4
+
+###############################################################################
+# Check for the presence of AVX2 and figure out the flags to use for it.
+function(CHECK_FOR_AVX2)
+  set(AVX_FLAGS)
+
+  include(CheckCXXSourceRuns)
+  
+  if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+    # Setting -march & -mtune just as required flags for check_cxx_source_runs,
+    # and CMAKE_REQUIRED_FLAGS will be restored after test runs.
+    set(CMAKE_REQUIRED_FLAGS "-march=native -mtune=native")
+  endif()
+
+  check_cxx_source_runs("    
+    #include <immintrin.h>
+    int main()
+    {
+      __m256i a = {0};
+      a = _mm256_abs_epi16(a);
+      return 0;
+    }"
+  HAVE_AVX2)
+
+  set(CMAKE_REQUIRED_FLAGS)
+
+# Setting the -mavx/-mavx2 defines __AVX(2)__, see here https://stackoverflow.com/a/28939692
+# and this allows the compiler to use the codes for AVX behind code guards.
+  if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+    if(HAVE_AVX2)
+      set(AVX_FLAGS "-mavx2" PARENT_SCOPE)
+    endif()
+  endif()
+
+# Setting the /arch defines __AVX(2)__, see here https://docs.microsoft.com/en-us/cpp/build/reference/arch-x64?view=msvc-160
+# AVX2 extends and includes AVX.
+# Setting these defines allows the compiler to use AVX instructions as well as code guarded with the defines.
+# TODO: Add AVX512 variant if needed.
+  if(MSVC)
+    if(HAVE_AVX2)
+      set(AVX_FLAGS "/arch:AVX2" PARENT_SCOPE)
+    endif()
+  endif()
+endfunction()

--- a/pixsfm/features/models/s2dnet.py
+++ b/pixsfm/features/models/s2dnet.py
@@ -77,7 +77,7 @@ class S2DNet(BaseModel):
         num_layers = self.hypercolumn_indices[-1] + 2  # also take the conv
 
         # Initialize architecture
-        vgg16 = models.vgg16(pretrained=conf.pretrained == 'imagenet')
+        vgg16 = models.vgg16()
         layers = list(vgg16.features.children())[:num_layers]
 
         if conf.remove_pooling_layers:


### PR DESCRIPTION
- Check if AVX2 is supported by the system if AVX2_ENABLED (the default). Disable AVX2 support if the check fails.
- fix a deprecation warning in S2DNet
Related to #20  #93