### PR TITLE
Updated include paths to match new Colmaps paths, removed alignment.h

### DIFF
--- a/pixsfm/base/src/projection.h
+++ b/pixsfm/base/src/projection.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <colmap/base/camera_models.h>
+#include <colmap/camera/models.h>
 #include <colmap/base/image.h>
 #include <colmap/base/projection.h>
 #include <colmap/util/math.h>

--- a/pixsfm/base/src/undistortion.h
+++ b/pixsfm/base/src/undistortion.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <colmap/base/camera_models.h>
+#include <colmap/camera/models.h>
 #include <colmap/base/image.h>
 #include <colmap/base/projection.h>
 #include <colmap/util/math.h>

--- a/pixsfm/base/src/undistortion_test.cc
+++ b/pixsfm/base/src/undistortion_test.cc
@@ -2,7 +2,7 @@
 #define TEST_NAME "base/undistortion"
 #include <colmap/util/testing.h>
 
-#include <colmap/base/undistortion.h>
+#include <colmap/image/undistortion.h>
 
 #include "base/src/undistortion.h"
 

--- a/pixsfm/bundle_adjustment/src/bundle_optimizer.h
+++ b/pixsfm/bundle_adjustment/src/bundle_optimizer.h
@@ -2,13 +2,12 @@
 
 #include <ceres/ceres.h>
 
-#include <colmap/base/camera_models.h>
+#include <colmap/camera/models.h>
 #include <colmap/base/camera_rig.h>
 #include <colmap/base/cost_functions.h>
 #include <colmap/base/projection.h>
 #include <colmap/base/reconstruction.h>
 #include <colmap/optim/bundle_adjustment.h>
-#include <colmap/util/alignment.h>
 #include <colmap/util/logging.h>
 #include <colmap/util/misc.h>
 #include <colmap/util/threading.h>

--- a/pixsfm/bundle_adjustment/src/bundle_optimizer_test.cc
+++ b/pixsfm/bundle_adjustment/src/bundle_optimizer_test.cc
@@ -33,7 +33,7 @@
 #define TEST_NAME "bundle_adjustment/bundle_optimizer"
 #include <colmap/util/testing.h>
 
-#include <colmap/base/camera_models.h>
+#include <colmap/camera/models.h>
 #include <colmap/base/correspondence_graph.h>
 #include <colmap/base/projection.h>
 #include <colmap/optim/bundle_adjustment.h>

--- a/pixsfm/keypoint_adjustment/src/keypoint_optimizer.h
+++ b/pixsfm/keypoint_adjustment/src/keypoint_optimizer.h
@@ -14,7 +14,6 @@ namespace py = pybind11;
 #include <colmap/base/projection.h>
 #include <colmap/base/reconstruction.h>
 #include <colmap/optim/bundle_adjustment.h>
-#include <colmap/util/alignment.h>
 #include <colmap/util/logging.h>
 #include <colmap/util/misc.h>
 #include <colmap/util/threading.h>

--- a/pixsfm/keypoint_adjustment/src/topological_keypoint_optimizer.h
+++ b/pixsfm/keypoint_adjustment/src/topological_keypoint_optimizer.h
@@ -6,7 +6,6 @@
 #include <colmap/base/projection.h>
 #include <colmap/base/reconstruction.h>
 #include <colmap/optim/bundle_adjustment.h>
-#include <colmap/util/alignment.h>
 #include <colmap/util/logging.h>
 #include <colmap/util/misc.h>
 #include <colmap/util/threading.h>


### PR DESCRIPTION
Fixes https://github.com/cvg/pixel-perfect-sfm/issues/110

I corrected the include paths, and also removed alignment.h from the includes. This file does not exist anymore in the colmap repository, and to me it looks like it was actually not used in this project.

With these fixes, you can successfully build again with the latest colmap repo changes.