### PR TITLE
Remove ANTIALIAS from list of filters (deprecated in PIL) (Fix #119)

### DIFF
--- a/pixsfm/features/extractor.py
+++ b/pixsfm/features/extractor.py
@@ -63,7 +63,7 @@ class FeatureExtractor:
 
     filters = {
         n: getattr(PIL.Image, n)
-        for n in ["BILINEAR", "BICUBIC", "ANTIALIAS", "LANCZOS"]
+        for n in ["BILINEAR", "BICUBIC", "LANCZOS"]
     }
 
     def __init__(self, conf: DictConfig, model: BaseModel = None):


### PR DESCRIPTION
Remove ANTIALIAS from list of filters (deprecated in PIL) (Fix #119)